### PR TITLE
Fix client session sharing

### DIFF
--- a/app/MobileNav.tsx
+++ b/app/MobileNav.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 
 import clsx from "clsx";
 
-import { FirstLevelNav, SessionNav, SquareLogo } from "./Navigation";
+import { FirstLevelNav, SquareLogo } from "./Navigation";
+import { SessionToolbar } from "./SessionToolbar";
 import { SecondLevelNav } from "./SiteNav";
 
 export const MobileNav = () => {
@@ -46,7 +47,7 @@ export const MobileNav = () => {
       >
         <FirstLevelNav />
         <SecondLevelNav />
-        <SessionNav />
+        <SessionToolbar />
       </div>
     </div>
   );

--- a/app/Navigation.tsx
+++ b/app/Navigation.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 import { Route } from "~/src/routing";
 
-import AuthContext, { SessionToolbar } from "./SessionToolbar";
+import { SessionToolbar } from "./SessionToolbar";
 import { SecondLevelNav } from "./SiteNav";
 
 export const DesktopNav = () => (
@@ -20,7 +20,7 @@ export const DesktopNav = () => (
         <SecondLevelNav />
       </div>
       <div className="ml-auto">
-        <SessionNav />
+        <SessionToolbar />
       </div>
     </div>
   </div>
@@ -66,10 +66,4 @@ export const FirstLevelNav = () => (
       </Link>
     </li>
   </ul>
-);
-
-export const SessionNav = () => (
-  <AuthContext>
-    <SessionToolbar />
-  </AuthContext>
 );

--- a/app/SessionToolbar.tsx
+++ b/app/SessionToolbar.tsx
@@ -1,17 +1,13 @@
 "use client";
 
-import { Fragment, type ReactNode } from "react";
+import { Fragment } from "react";
 import Image from "next/image";
 import Link from "next/link";
 
 import { type Session } from "next-auth";
-import { SessionProvider, signIn, useSession } from "next-auth/react";
+import { signIn, useSession } from "next-auth/react";
 
 import { Route } from "~/src/routing";
-
-export default function AuthContext({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
-}
 
 export const SessionToolbar = () => {
   const { data: session, status } = useSession();

--- a/app/events/[slug]/QuickRegistrationButton.tsx
+++ b/app/events/[slug]/QuickRegistrationButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { SessionProvider, signIn, useSession } from "next-auth/react";
+import { signIn, useSession } from "next-auth/react";
 
 import { useJSONResource } from "~/components/hooks/resource";
 import { type Event } from "~/src/data/event";
@@ -9,7 +9,7 @@ type RegistrationStatus = {
   registered: boolean;
 };
 
-const QuickRegistrationButton = ({ event }: { event: Event }) => {
+export const QuickRegistrationButton = ({ event }: { event: Event }) => {
   const { status: sessionStatus } = useSession();
   const url = `/events/${event.slug}/registration-status`;
   const { model, setModel, updating } = useJSONResource<RegistrationStatus>({
@@ -47,11 +47,3 @@ const QuickRegistrationButton = ({ event }: { event: Event }) => {
     );
   }
 };
-
-const SessionWrappedButton = ({ event }: { event: Event }) => (
-  <SessionProvider>
-    <QuickRegistrationButton event={event} />
-  </SessionProvider>
-);
-
-export { SessionWrappedButton as QuickRegistrationButton };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 
 import "./globals.css";
 
+import { SessionProvider } from "components/SessionProvider";
+
 import { MobileNav } from "./MobileNav";
 import { DesktopNav } from "./Navigation";
 
@@ -31,8 +33,10 @@ export default async function RootLayout({
         />
       </head>
       <body>
-        <NavigationBar />
-        {children}
+        <SessionProvider>
+          <NavigationBar />
+          {children}
+        </SessionProvider>
       </body>
     </html>
   );

--- a/components/SessionProvider.tsx
+++ b/components/SessionProvider.tsx
@@ -1,0 +1,3 @@
+"use client";
+
+export { SessionProvider } from "next-auth/react";


### PR DESCRIPTION
Špatně jsem rozuměl tomu, jak funguje sdílení session, a proto jsme s ní na klientovi pracovali trochu bizarně – toto by mělo být lepší. Mimo jiné closes #963. Hlavní změna je v tom, že `SessionProvider` dáváme až do kořene celé aplikace. Dřív jsme ho tam neměli, protože to musí být klientská komponenta a já jsem si myslel, že by kvůli tomu musel běžet celý podstrom na klientovi – což, pokud to dobře chápu, není pravda. Takže teď máme klientskou komponentu se session v kořeni celé aplikace a libovolná klientská komponenta v tom podstromu se k session snadno dostane.