### PR TITLE
Možnosť nahrať a zmazať profilovú foto v nastaveniach profilu

### DIFF
--- a/app/SessionToolbar.tsx
+++ b/app/SessionToolbar.tsx
@@ -12,6 +12,7 @@ import { defaultAvatarUrl } from "~/src/utils";
 
 export const SessionToolbar = () => {
   const { data: session, status } = useSession();
+  console.log(session, "ssn");
   return (
     <Fragment>
       {status === "loading" && <SignedOutButtons />}
@@ -23,6 +24,7 @@ export const SessionToolbar = () => {
 
 const SignedInButtons = ({ session }: { session: Session }) => {
   const avatarImage = session.user?.image ?? defaultAvatarUrl;
+
   const avatarTitle =
     session.user?.name && session.user?.email
       ? `${session.user?.name} (${session.user?.email})`

--- a/app/account/UserProfileTab.tsx
+++ b/app/account/UserProfileTab.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 
 import clsx from "clsx";
 
+import { UploadImage } from "~/app/upload/UploadImage";
 import { CopyToClipboardButton } from "~/components/CopyToClipboardButton";
 import { DistrictSelect } from "~/components/districts/DistrictSelect";
 import { FormError } from "~/components/form/FormError";
@@ -23,7 +24,7 @@ import {
   type SkillSelection,
 } from "~/src/skills/skills";
 import skills from "~/src/skills/skills.json";
-import { looksLikeEmailAdress } from "~/src/utils";
+import { defaultAvatarUrl, looksLikeEmailAdress } from "~/src/utils";
 
 type SectionProps = {
   model?: UserProfile;
@@ -52,6 +53,15 @@ export const UserProfileTab = () => {
 };
 
 const BioSection = ({ model, updating, onChange }: SectionProps) => {
+  const [avatarImage, setAvatarImage] = useState("");
+  useEffect(() => {
+    setAvatarImage(model?.avatarUrl ?? defaultAvatarUrl);
+  }, [model]);
+
+  const onAvatarChange = (url: string) => {
+    onChange({ ...model!, avatarUrl: url });
+  };
+
   return (
     <section className="flex max-w-prose flex-col gap-7">
       <h2 className="typo-title2">Základní informace</h2>
@@ -62,6 +72,24 @@ const BioSection = ({ model, updating, onChange }: SectionProps) => {
         >
           Zobrazit profil
         </a>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="avatarImage" className="block">
+          Profilová fotka:
+        </label>
+        <img
+          src={avatarImage}
+          className="h-[100px] w-[100px] rounded-full bg-gray object-cover shadow"
+          alt="avatarImage"
+        />
+        <div className="space-y-2">
+          <UploadImage
+            setAvatarImage={setAvatarImage}
+            avatarImage={avatarImage}
+            onChange={onAvatarChange}
+          />
+        </div>
       </div>
 
       <div className="flex flex-col gap-2">
@@ -286,7 +314,6 @@ const WorkSection = ({ model, updating, onChange }: SectionProps) => {
     </section>
   );
 };
-
 
 const SkillSection = ({ model, updating, onChange }: SectionProps) => {
   const selection = model ? decodeSkillSelection(model.skills) : {};

--- a/app/account/UserProfileTab.tsx
+++ b/app/account/UserProfileTab.tsx
@@ -55,11 +55,11 @@ export const UserProfileTab = () => {
 const BioSection = ({ model, updating, onChange }: SectionProps) => {
   const [avatarImage, setAvatarImage] = useState("");
   useEffect(() => {
-    setAvatarImage(model?.avatarUrl ?? defaultAvatarUrl);
+    setAvatarImage(model?.profilePictureUrl ?? defaultAvatarUrl);
   }, [model]);
 
   const onAvatarChange = (url: string) => {
-    onChange({ ...model!, avatarUrl: url });
+    onChange({ ...model!, profilePictureUrl: url });
   };
 
   return (
@@ -72,24 +72,6 @@ const BioSection = ({ model, updating, onChange }: SectionProps) => {
         >
           Zobrazit profil
         </a>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <label htmlFor="avatarImage" className="block">
-          Profilová fotka:
-        </label>
-        <img
-          src={avatarImage}
-          className="h-[100px] w-[100px] rounded-full bg-gray object-cover shadow"
-          alt="avatarImage"
-        />
-        <div className="space-y-2">
-          <UploadImage
-            setAvatarImage={setAvatarImage}
-            avatarImage={avatarImage}
-            onChange={onAvatarChange}
-          />
-        </div>
       </div>
 
       <div className="flex flex-col gap-2">
@@ -123,6 +105,24 @@ const BioSection = ({ model, updating, onChange }: SectionProps) => {
         defaultValue={model?.name}
         onSave={(name) => onChange({ ...model!, name })}
       />
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="avatarImage" className="block">
+          Profilová fotka:
+        </label>
+        <img
+          src={avatarImage}
+          className="h-[100px] w-[100px] rounded-full bg-gray object-cover shadow"
+          alt="avatarImage"
+        />
+        <div className="space-y-2">
+          <UploadImage
+            setAvatarImage={setAvatarImage}
+            avatarImage={avatarImage}
+            onAvatarChange={onAvatarChange}
+          />
+        </div>
+      </div>
 
       <InputWithSaveButton
         id="contactMail"

--- a/app/account/UserProfileTab.tsx
+++ b/app/account/UserProfileTab.tsx
@@ -59,10 +59,6 @@ const BioSection = ({ model, updating, onChange }: SectionProps) => {
     setAvatarImage(model?.profilePictureUrl ?? defaultAvatarUrl);
   }, [model]);
 
-  // const onAvatarChange = (url: string) => {
-  //   onChange({ ...model!, profilePictureUrl: url });
-  // };
-
   return (
     <section className="flex max-w-prose flex-col gap-7">
       <h2 className="typo-title2">Základní informace</h2>

--- a/app/account/UserProfileTab.tsx
+++ b/app/account/UserProfileTab.tsx
@@ -5,11 +5,12 @@ import {
   type HTMLInputTypeAttribute,
   type InputHTMLAttributes,
 } from "react";
+import Image from "next/image";
 import Link from "next/link";
 
 import clsx from "clsx";
 
-import { UploadImage } from "~/app/upload/UploadImage";
+import { ImageUploader } from "~/app/upload/ImageUploader";
 import { CopyToClipboardButton } from "~/components/CopyToClipboardButton";
 import { DistrictSelect } from "~/components/districts/DistrictSelect";
 import { FormError } from "~/components/form/FormError";
@@ -58,9 +59,9 @@ const BioSection = ({ model, updating, onChange }: SectionProps) => {
     setAvatarImage(model?.profilePictureUrl ?? defaultAvatarUrl);
   }, [model]);
 
-  const onAvatarChange = (url: string) => {
-    onChange({ ...model!, profilePictureUrl: url });
-  };
+  // const onAvatarChange = (url: string) => {
+  //   onChange({ ...model!, profilePictureUrl: url });
+  // };
 
   return (
     <section className="flex max-w-prose flex-col gap-7">
@@ -110,16 +111,20 @@ const BioSection = ({ model, updating, onChange }: SectionProps) => {
         <label htmlFor="avatarImage" className="block">
           Profilová fotka:
         </label>
-        <img
+        <Image
           src={avatarImage}
           className="h-[100px] w-[100px] rounded-full bg-gray object-cover shadow"
-          alt="avatarImage"
+          alt="Profilová foto"
+          width={100}
+          height={100}
         />
         <div className="space-y-2">
-          <UploadImage
+          <ImageUploader
             setAvatarImage={setAvatarImage}
             avatarImage={avatarImage}
-            onAvatarChange={onAvatarChange}
+            onAvatarChange={(url: string) => {
+              onChange({ ...model!, profilePictureUrl: url });
+            }}
           />
         </div>
       </div>

--- a/app/account/me/route.ts
+++ b/app/account/me/route.ts
@@ -90,6 +90,7 @@ export async function PATCH(request: NextRequest) {
       occupation,
       organizationName,
       profileUrl,
+      profilePictureUrl,
     } = await request.json();
     await updateUserProfile(profile.id, {
       name,
@@ -102,6 +103,7 @@ export async function PATCH(request: NextRequest) {
       occupation,
       organizationName,
       profileUrl,
+      profilePictureUrl,
     });
     return new Response("Updated", { status: 200 });
   });

--- a/app/account/picture/route.ts
+++ b/app/account/picture/route.ts
@@ -1,0 +1,54 @@
+import crypto from "crypto";
+
+import { NextResponse } from "next/server";
+
+import { put } from "@vercel/blob";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "~/src/auth";
+
+export async function POST(request: Request): Promise<Response> {
+  // Only allow signed-in users to upload assets
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  if (!request.body) {
+    return new Response("Missing payload", { status: 400 });
+  }
+
+  // We use the original filename to get the extension
+  const { searchParams } = new URL(request.url);
+  const originalFilename = searchParams.get("filename");
+  if (!originalFilename) {
+    return new Response("Missing filename", { status: 400 });
+  }
+
+  // But the file name itself is an 8-character prefix of the SHA1
+  // of file content
+  const data = await getArrayBufferView(request.body);
+  const hash = shasumPrefix(new Uint8Array(data));
+  const target = hash + "." + getFilenameExtension(originalFilename);
+
+  // Upload
+  const blob = await put(target, data, {
+    addRandomSuffix: false,
+    access: "public",
+    token: process.env.USER_BLOB_READ_WRITE_TOKEN,
+  });
+
+  const result = NextResponse.json(blob);
+  console.log("result", result);
+
+  return result;
+}
+
+const getArrayBufferView = async (data: ReadableStream<Uint8Array>) =>
+  new Response(data).arrayBuffer();
+
+const shasumPrefix = (data: crypto.BinaryLike) =>
+  crypto.createHash("sha1").update(data).digest("hex").slice(0, 8);
+
+const getFilenameExtension = (name: string) =>
+  name.split(".").pop()?.toLowerCase();

--- a/app/account/picture/route.ts
+++ b/app/account/picture/route.ts
@@ -3,43 +3,37 @@ import crypto from "crypto";
 import { NextResponse } from "next/server";
 
 import { put } from "@vercel/blob";
-import { getServerSession } from "next-auth";
 
-import { authOptions } from "~/src/auth";
+import { withAuthenticatedUser } from "~/src/auth";
 
 export async function POST(request: Request): Promise<Response> {
-  // Only allow signed-in users to upload photo
-  const session = await getServerSession(authOptions);
-  if (!session?.user) {
-    return new Response("Unauthorized", { status: 401 });
-  }
+  return withAuthenticatedUser(async () => {
+    if (!request.body) {
+      return new Response("Missing payload", { status: 400 });
+    }
 
-  if (!request.body) {
-    return new Response("Missing payload", { status: 400 });
-  }
+    // We use the original filename to get the extension
+    const { searchParams } = new URL(request.url);
+    const originalFilename = searchParams.get("filename");
+    if (!originalFilename) {
+      return new Response("Missing filename", { status: 400 });
+    }
 
-  // We use the original filename to get the extension
-  const { searchParams } = new URL(request.url);
-  const originalFilename = searchParams.get("filename");
-  if (!originalFilename) {
-    return new Response("Missing filename", { status: 400 });
-  }
+    // But the file name itself is an 8-character prefix of the SHA1
+    // of file content
+    const data = await getArrayBufferView(request.body);
+    const hash = shasumPrefix(new Uint8Array(data));
+    const target = hash + "." + getFilenameExtension(originalFilename);
 
-  // But the file name itself is an 8-character prefix of the SHA1
-  // of file content
-  const data = await getArrayBufferView(request.body);
-  const hash = shasumPrefix(new Uint8Array(data));
-  const target = hash + "." + getFilenameExtension(originalFilename);
+    // Upload
+    const blob = await put(target, data, {
+      addRandomSuffix: false,
+      access: "public",
+      token: process.env.USER_BLOB_READ_WRITE_TOKEN,
+    });
 
-  // Upload
-  const blob = await put(target, data, {
-    addRandomSuffix: false,
-    access: "public",
-    token: process.env.USER_BLOB_READ_WRITE_TOKEN,
+    return NextResponse.json(blob);
   });
-
-  const result = NextResponse.json(blob);
-  return result;
 }
 
 const getArrayBufferView = async (data: ReadableStream<Uint8Array>) =>

--- a/app/account/picture/route.ts
+++ b/app/account/picture/route.ts
@@ -8,7 +8,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "~/src/auth";
 
 export async function POST(request: Request): Promise<Response> {
-  // Only allow signed-in users to upload assets
+  // Only allow signed-in users to upload photo
   const session = await getServerSession(authOptions);
   if (!session?.user) {
     return new Response("Unauthorized", { status: 401 });
@@ -39,8 +39,6 @@ export async function POST(request: Request): Promise<Response> {
   });
 
   const result = NextResponse.json(blob);
-  console.log("result", result);
-
   return result;
 }
 

--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -113,7 +113,7 @@ const EventSidebar = ({
       <SidebarSection title="Kontakt">
         <ImageLabel
           link={Route.toProfile({ id: owner.id })}
-          imageUrl={owner.avatarUrl}
+          imageUrl={owner.profilePictureUrl}
           label={owner.name}
         />
       </SidebarSection>

--- a/app/opportunities/[slug]/page.tsx
+++ b/app/opportunities/[slug]/page.tsx
@@ -97,7 +97,7 @@ const RoleSidebar = ({
     <SidebarSection title="Kontaktní osoba">
       <ImageLabel
         link={Route.toProfile({ id: owner.id })}
-        imageUrl={owner.avatarUrl}
+        imageUrl={owner.profilePictureUrl}
         label={owner.name}
       />
     </SidebarSection>

--- a/app/people/[id]/page.tsx
+++ b/app/people/[id]/page.tsx
@@ -193,7 +193,7 @@ const ProjectSection = ({ engagements }: EngagementProps) => {
 const Avatar = ({ profile }: ProfileProps) => (
   <div className="relative mx-auto aspect-square w-[200px]">
     <Image
-      src={profile.avatarUrl}
+      src={profile.profilePictureUrl}
       className="aspect-square rounded-full bg-pebble object-cover object-top"
       width={200}
       height={200}

--- a/app/projects/[slug]/ProjectTeamSection.tsx
+++ b/app/projects/[slug]/ProjectTeamSection.tsx
@@ -19,17 +19,20 @@ export const ProjectTeamSection = ({
         <div key={label} className="mb-7">
           <h2 className="typo-title2 mb-4">{label}</h2>
           <UserProfileContainer>
-            {engagements.map((e) => (
-              <UserProfileCard
-                key={e.id}
-                label={e.projectRole}
-                profile={{
-                  id: e.userId,
-                  name: e.userName,
-                  profilePicutureUrl: e.userAvatarUrl ?? defaultAvatarUrl,
-                }}
-              />
-            ))}
+            {engagements.map((e) => {
+              console.log(e);
+              return (
+                <UserProfileCard
+                  key={e.id}
+                  label={e.projectRole}
+                  profile={{
+                    id: e.userId,
+                    name: e.userName,
+                    profilePictureUrl: e.profilePictureUrl,
+                  }}
+                />
+              );
+            })}
           </UserProfileContainer>
         </div>
       ))}

--- a/app/projects/[slug]/ProjectTeamSection.tsx
+++ b/app/projects/[slug]/ProjectTeamSection.tsx
@@ -26,7 +26,7 @@ export const ProjectTeamSection = ({
                 profile={{
                   id: e.userId,
                   name: e.userName,
-                  avatarUrl: e.userAvatarUrl ?? defaultAvatarUrl,
+                  profilePictureUrl: e.userAvatarUrl ?? defaultAvatarUrl,
                 }}
               />
             ))}

--- a/app/projects/[slug]/ProjectTeamSection.tsx
+++ b/app/projects/[slug]/ProjectTeamSection.tsx
@@ -26,7 +26,7 @@ export const ProjectTeamSection = ({
                 profile={{
                   id: e.userId,
                   name: e.userName,
-                  profilePictureUrl: e.userAvatarUrl ?? defaultAvatarUrl,
+                  profilePicutureUrl: e.userAvatarUrl ?? defaultAvatarUrl,
                 }}
               />
             ))}

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -30,6 +30,7 @@ import "react-lite-youtube-embed/dist/LiteYouTubeEmbed.css";
 import { type Metadata } from "next";
 
 import { iconForUrl } from "~/components/icons";
+import { defaultAvatarUrl } from "~/src/utils";
 
 import { ProjectTeamSection } from "./ProjectTeamSection";
 
@@ -245,7 +246,7 @@ const ProjectSidebar = ({
         <ImageLabel
           key={c.id}
           link={Route.toProfile({ id: c.userId })}
-          imageUrl={c.userAvatarUrl}
+          imageUrl={c.profilePictureUrl ?? defaultAvatarUrl}
           label={c.userName}
           faded={c.inactive}
         />

--- a/app/upload/ImageUploader.tsx
+++ b/app/upload/ImageUploader.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useRef, useState, type FormEvent } from "react";
 
 import { type PutBlobResult } from "@vercel/blob";
@@ -9,12 +7,12 @@ import { FormError } from "~/components/form/FormError";
 import { defaultAvatarUrl } from "~/src/utils";
 
 type Props = {
-  setAvatarImage: React.Dispatch<React.SetStateAction<string>>;
+  setAvatarImage: (url: string) => void;
   avatarImage: string;
   onAvatarChange: (url: string) => void;
 };
 
-export const UploadImage = ({
+export const ImageUploader = ({
   setAvatarImage,
   avatarImage,
   onAvatarChange,

--- a/app/upload/ImageUploader.tsx
+++ b/app/upload/ImageUploader.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, type FormEvent } from "react";
 
 import { type PutBlobResult } from "@vercel/blob";
 import clsx from "clsx";
+import { useSession } from "next-auth/react";
 
 import { FormError } from "~/components/form/FormError";
 import { defaultAvatarUrl } from "~/src/utils";
@@ -21,6 +22,8 @@ export const ImageUploader = ({
   const [uploading, setUploading] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [pendingChanges, setPendingChanges] = useState(false);
+
+  const { data: session, update } = useSession();
 
   const cleanInputFile = () => {
     if (inputFileRef.current) {
@@ -55,6 +58,7 @@ export const ImageUploader = ({
       const newBlob = (await response.json()) as PutBlobResult;
       cleanInputFile();
       onAvatarChange(newBlob.url);
+      await update({ image: newBlob.url });
     } else {
       setErrorMessage("Něco se nepovedlo, zkus to znovu");
     }
@@ -92,10 +96,11 @@ export const ImageUploader = ({
     fileReader.readAsDataURL(file);
   };
 
-  const onDelete = () => {
+  const onDelete = async () => {
     cleanInputFile();
     setAvatarImage(defaultAvatarUrl);
     onAvatarChange(defaultAvatarUrl);
+    await update({ image: defaultAvatarUrl });
   };
 
   return (

--- a/app/upload/UploadImage.tsx
+++ b/app/upload/UploadImage.tsx
@@ -124,7 +124,7 @@ export const UploadImage = ({
             )}
             disabled={uploading}
           >
-            Uložit profilovou fotku
+            Uložit fotku
           </button>
           <button
             className={clsx(
@@ -135,7 +135,7 @@ export const UploadImage = ({
             onClick={onDelete}
             disabled={uploading}
           >
-            Smazat profilovou fotku
+            Smazat fotku
           </button>
         </div>
       </form>

--- a/app/upload/UploadImage.tsx
+++ b/app/upload/UploadImage.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useRef, useState, type FormEvent } from "react";
+
+import { type PutBlobResult } from "@vercel/blob";
+import clsx from "clsx";
+
+import { FormError } from "~/components/form/FormError";
+import { defaultAvatarUrl } from "~/src/utils";
+
+type Props = {
+  setAvatarImage: React.Dispatch<React.SetStateAction<string>>;
+  avatarImage: string;
+  onChange: (url: string) => void;
+};
+
+export const UploadImage = ({
+  setAvatarImage,
+  avatarImage,
+  onChange,
+}: Props) => {
+  const inputFileRef = useRef<HTMLInputElement>(null);
+  // const [blob, setBlob] = useState<PutBlobResult | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [pendingChanges, setPendingChanges] = useState(false);
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!inputFileRef.current?.files) {
+      throw new Error("No file selected");
+    }
+
+    const file = inputFileRef.current.files[0];
+
+    setUploading(true);
+    const response = await fetch(`/account/picture?filename=${file.name}`, {
+      method: "POST",
+      body: file,
+    });
+
+    if (response.ok) {
+      const newBlob = (await response.json()) as PutBlobResult;
+      setUploading(false);
+      onChange(newBlob.url);
+    } else {
+      setUploading(false);
+    }
+  };
+
+  const uploadHandler = () => {
+    setErrorMessage("");
+    setPendingChanges(true);
+    if (!inputFileRef.current?.files) {
+      throw new Error("No file selected");
+    }
+
+    const file = inputFileRef.current.files[0];
+
+    if (file.size > 4500000) {
+      setErrorMessage("Soubor musí být menší než 4.5 MB");
+      if (inputFileRef.current) {
+        inputFileRef.current.value = "";
+      }
+      setAvatarImage(defaultAvatarUrl);
+      setPendingChanges(false);
+      return;
+    }
+    if (!file.type.startsWith("image/")) {
+      setErrorMessage("Soubor musí mít formát obrázku");
+      if (inputFileRef.current) {
+        inputFileRef.current.value = "";
+      }
+      setAvatarImage(defaultAvatarUrl);
+      setPendingChanges(false);
+      return;
+    }
+    const fileReader = new FileReader();
+    fileReader.onload = (e) => {
+      if (e.target && typeof e.target.result === "string") {
+        setAvatarImage(e.target.result);
+      } else {
+        throw new Error("FileReader result is not a string");
+      }
+    };
+    fileReader.readAsDataURL(file);
+  };
+
+  const handleRemoval = () => {
+    if (inputFileRef.current) {
+      inputFileRef.current.value = "";
+    }
+    setAvatarImage(defaultAvatarUrl);
+    setPendingChanges(false);
+    onChange(defaultAvatarUrl);
+  };
+
+  return (
+    <div>
+      <form onSubmit={onSubmit} className="flex flex-col gap-7">
+        <input
+          className="max-w-prose"
+          name="file"
+          ref={inputFileRef}
+          type="file"
+          required
+          onChange={uploadHandler}
+        />
+        {errorMessage && (
+          <div className="py-1">
+            <FormError error={errorMessage} />
+          </div>
+        )}
+        <div className="flex gap-2">
+          <button
+            type="submit"
+            className={clsx(
+              uploading || !pendingChanges ? "btn-disabled" : "btn-primary",
+            )}
+            disabled={uploading}
+          >
+            {uploading ? "Ukladam" : "Uložit profilovou fotku"}
+          </button>
+          <button
+            className={clsx(
+              uploading || avatarImage === defaultAvatarUrl
+                ? "btn-disabled"
+                : "btn-inverted",
+            )}
+            onClick={handleRemoval}
+            disabled={uploading}
+          >
+            Smazat profilovou fotku
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/components/UserProfileCard.tsx
+++ b/components/UserProfileCard.tsx
@@ -8,7 +8,7 @@ import { type UserProfile } from "~/src/data/user-profile";
 import { Route } from "~/src/routing";
 
 export type Props = {
-  profile: Pick<UserProfile, "name" | "avatarUrl" | "id"> &
+  profile: Pick<UserProfile, "name" | "profilePictureUrl" | "id"> &
     Partial<Pick<UserProfile, "roles">>;
   label?: string;
 };
@@ -25,7 +25,7 @@ export const UserProfileCard = ({ profile, label }: Props) => (
     <div className="shrink-0">
       <div className="relative mx-auto w-[80px]">
         <Image
-          src={profile.avatarUrl}
+          src={profile.profilePictureUrl}
           className={clsx(
             "shrink-0 rounded-full bg-gray shadow",
             // This fixes the appearance of non-square images

--- a/components/districts/districts.ts
+++ b/components/districts/districts.ts
@@ -5,7 +5,7 @@ import sourceData from "./districts.json";
 /** Map member is a subset of user profile containing just the necessary fields */
 export type MapMember = Pick<
   UserProfile,
-  "name" | "slackId" | "slackAvatarUrl" | "slackProfileUrl"
+  "name" | "slackId" | "profilePictureUrl" | "slackProfileUrl"
 >;
 
 /** Map model is a map where the keys are district names and the values are lists of users in given district */

--- a/next.config.js
+++ b/next.config.js
@@ -28,6 +28,10 @@ module.exports = withAxiom({
       },
       {
         protocol: "https",
+        hostname: "mogrfyhmal8klgqy.public.blob.vercel-storage.com",
+      },
+      {
+        protocol: "https",
         hostname: "avatars.slack-edge.com",
       },
       {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -63,6 +63,16 @@ export const authOptions: NextAuthOptions = {
   ],
 
   callbacks: {
+    jwt({ token, trigger, session, user }) {
+      if (user?.image) {
+        token.image = user.image;
+      }
+      if (trigger === "update") {
+        token.image = session.image;
+      }
+      return token;
+    },
+
     async signIn({ user }) {
       if (user.email) {
         const existingUser = await getUserByEmail(user.email);
@@ -87,6 +97,7 @@ export const authOptions: NextAuthOptions = {
       if (session.user) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (session.user as any as OurUser).id = token.sub!;
+        session.user.image = token.image;
       }
       return session;
     },

--- a/src/data/auth.ts
+++ b/src/data/auth.ts
@@ -43,7 +43,7 @@ interface UserTableSchema extends FieldSet {
   email: string;
   emailVerified: string;
   name: string;
-  userProfileUrl: string;
+  profilePictureUrl: string;
   state: string;
 }
 
@@ -54,7 +54,7 @@ const decodeUser = record({
   email: string,
   emailVerified: optionalAsNull(date),
   name: optionalAsNull(string),
-  image: field("userProfileUrl", relationToZeroOrOne),
+  image: field("profilePictureUrl", relationToZeroOrOne),
 });
 
 const encodeUser = (user: Partial<User>): Partial<UserTableSchema> => ({

--- a/src/data/auth.ts
+++ b/src/data/auth.ts
@@ -43,7 +43,7 @@ interface UserTableSchema extends FieldSet {
   email: string;
   emailVerified: string;
   name: string;
-  slackAvatarUrl: string;
+  userProfileUrl: string;
   state: string;
 }
 
@@ -54,7 +54,7 @@ const decodeUser = record({
   email: string,
   emailVerified: optionalAsNull(date),
   name: optionalAsNull(string),
-  image: field("slackAvatarUrl", relationToZeroOrOne),
+  image: field("userProfileUrl", relationToZeroOrOne),
 });
 
 const encodeUser = (user: Partial<User>): Partial<UserTableSchema> => ({

--- a/src/data/team-engagement.ts
+++ b/src/data/team-engagement.ts
@@ -14,6 +14,7 @@ import {
   takeFirst,
   withDefault,
 } from "~/src/decoding";
+import { defaultAvatarUrl } from "~/src/utils";
 
 import { appBase, unwrapRecords } from "./airtable";
 
@@ -45,6 +46,7 @@ export const decodeTeamEngagement = record({
   fields: optionalArray(string),
   inactive: withDefault(boolean, false),
   startDate: optional(string),
+  profilePictureUrl: withDefault(string, defaultAvatarUrl),
 });
 
 //

--- a/src/data/user-profile.test.ts
+++ b/src/data/user-profile.test.ts
@@ -43,6 +43,7 @@ test("Decode user with no skills", () => {
     gdprPolicyAcceptedAt: undefined,
     codeOfConductAcceptedAt: undefined,
     daysSinceRegistered: undefined,
+    profilePictureUrl: defaultAvatarUrl,
   });
 });
 
@@ -87,6 +88,7 @@ test("Decode Slack Users relation", () => {
     gdprPolicyAcceptedAt: undefined,
     codeOfConductAcceptedAt: undefined,
     daysSinceRegistered: undefined,
+    profilePictureUrl: defaultAvatarUrl,
   });
   expect(
     decodeUserProfile({
@@ -128,6 +130,7 @@ test("Decode Slack Users relation", () => {
     gdprPolicyAcceptedAt: undefined,
     codeOfConductAcceptedAt: undefined,
     daysSinceRegistered: undefined,
+    profilePictureUrl: defaultAvatarUrl,
   });
 });
 

--- a/src/data/user-profile.ts
+++ b/src/data/user-profile.ts
@@ -62,6 +62,7 @@ export interface Schema extends FieldSet {
   state: string;
   createdAt: string;
   lastModifiedAt: string;
+  profilePicture: string;
 }
 
 /** The user profile table in Airtable */
@@ -113,6 +114,7 @@ export const decodeUserProfile = record({
   createdAt: optional(string),
   lastModifiedAt: string,
   daysSinceRegistered: optional(number),
+  profilePictureUrl: withDefault(string, defaultAvatarUrl),
 });
 
 /** Encode `UserProfile` to DB schema */
@@ -140,7 +142,7 @@ export function encodeUserProfile(
     gdprPolicyAcceptedAt: profile.gdprPolicyAcceptedAt,
     codeOfConductAcceptedAt: profile.codeOfConductAcceptedAt,
     bio: profile.bio,
-    avatarUrl: profile.avatarUrl,
+    profilePictureUrl: profile.profilePictureUrl,
   };
 }
 
@@ -212,6 +214,7 @@ export async function updateUserProfile(
       | "occupation"
       | "profileUrl"
       | "organizationName"
+      | "profilePictureUrl"
     >
   >,
 ): Promise<UserProfile> {
@@ -240,6 +243,7 @@ export async function createUserProfile(
     | "codeOfConductAcceptedAt"
     | "featureFlags"
     | "privacyFlags"
+    | "profilePictureUrl"
   >,
 ): Promise<UserProfile> {
   return await userProfileTable

--- a/src/data/user-profile.ts
+++ b/src/data/user-profile.ts
@@ -140,6 +140,7 @@ export function encodeUserProfile(
     gdprPolicyAcceptedAt: profile.gdprPolicyAcceptedAt,
     codeOfConductAcceptedAt: profile.codeOfConductAcceptedAt,
     bio: profile.bio,
+    avatarUrl: profile.avatarUrl,
   };
 }
 


### PR DESCRIPTION
Čo je hotové:

- ako výchozí je aktuálna slack foto alebo default avatar (teda bude po migrácii dát)
- užívateľ vie nahrať novú foto (overuje sa jej veľkosť a typ súboru) a vidí preview
- foto je možné zmazať (ostane default avatar)
- všetky potvrdené zmeny (uloženie novej foto a zmazanie) sa ukladajú do databáze do políčka `profilePictureUrl`

TODO / problémy:

- [x] nenastavovala som pre existujúci uploader súborov do ktorého blob storage sa majú nahrávať, teraz keď máme 2 storage asi to bude treba jasne špecifikovať aj pre neho
- [x] typescript ma varuje pred tým, že si posúvam dve funkcie do `use client` komponenty (`UploadImage`) ako props, naoko to funguje ako má ale neviem posúdiť ako veľmi nebezpečné to je... Posúvam si setter stavu `avatarImage` a funkciu na update foto v databáze (`onAvatarChange`)
- [x] neviem úspešne docieliť aby sa nová fotka zobrazovala všade kde používame avatara, napr navbar alebo v detaile projektu... jeden z problémov je, že bude treba nastaviť presmerovanie z `https://mogrfyhmal8klgqy.public.blob.vercel-storage.com/:file` na `assets.cesko.digital/:file` plus sa pohrať s typmi (nie všade stačí nahradiť rovno `avatarUrl` za `profilePictureUrl`..)